### PR TITLE
Bump jmh-generator-annprocess from 1.34 to 1.35

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$JUNIT5_VERSION"
 
-    jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.34'
+    jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.35'
     jmh 'org.openjdk.jmh:jmh-core:1.34'
 }
 


### PR DESCRIPTION
Bumps jmh-generator-annprocess from 1.34 to 1.35.

---
updated-dependencies:
- dependency-name: org.openjdk.jmh:jmh-generator-annprocess
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>